### PR TITLE
Update huawei_lte_lib.py broken dependancy

### DIFF
--- a/huawei-lte-band/huawei_lte_lib.py
+++ b/huawei-lte-band/huawei_lte_lib.py
@@ -1,6 +1,6 @@
 from huawei_lte_api.Client import Client
 from huawei_lte_api.AuthorizedConnection import AuthorizedConnection
-from huawei_lte_api.exceptions import ResponseErrorLoginCsfrException
+from huawei_lte_api.exceptions import ResponseErrorLoginCsrfException
 from huawei_lte_api.exceptions import LoginErrorUsernamePasswordWrongException
 import requests
 


### PR DESCRIPTION
Repairs dependency broken with huawei-lte-api commit #cb3b41f86a66926c852871b48c0494e1b7a2b1da
Exception ResponseErrorLoginCsfrException -> ResponseErrorLoginCsrfException rename